### PR TITLE
fix: change import name from 'Vue' to 'vue' on event-bus plugin

### DIFF
--- a/src/plugins/event-bus.js
+++ b/src/plugins/event-bus.js
@@ -1,5 +1,5 @@
 
-import Vue from 'Vue'
+import Vue from 'vue'
 
 const bus = new Vue()
 


### PR DESCRIPTION
Esse pull-request corrige a importação do VueJS no arquivo event-bus.js que esta declarado como 'Vue' sendo o correto 'vue'.